### PR TITLE
feat: 新增系统监控 Dashboard 页面

### DIFF
--- a/backend/agentpal/api/v1/endpoints/dashboard.py
+++ b/backend/agentpal/api/v1/endpoints/dashboard.py
@@ -1,0 +1,172 @@
+"""Dashboard 统计 API — 聚合展示系统运行指标。"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from agentpal.database import get_db
+from agentpal.models.cron import CronJob, CronJobExecution
+from agentpal.models.memory import MemoryRecord
+from agentpal.models.session import SessionRecord, SubAgentTask
+from agentpal.models.skill import SkillRecord
+from agentpal.models.tool import ToolCallLog
+
+router = APIRouter()
+
+
+class DashboardStats(BaseModel):
+    total_sessions: int = 0
+    sessions_by_channel: dict[str, int] = {}
+    total_messages: int = 0
+    total_tokens: int = 0
+    models_in_use: dict[str, int] = {}
+    total_tool_calls: int = 0
+    tool_calls_by_name: dict[str, int] = {}
+    tool_errors: int = 0
+    avg_tool_duration_ms: float = 0.0
+    total_skills: int = 0
+    enabled_skills: int = 0
+    total_cron_jobs: int = 0
+    enabled_cron_jobs: int = 0
+    cron_executions: int = 0
+    cron_failures: int = 0
+    total_errors: int = 0
+    sub_agent_tasks: int = 0
+    sub_agent_failures: int = 0
+
+
+@router.get("/stats", response_model=DashboardStats)
+async def get_dashboard_stats(db: AsyncSession = Depends(get_db)) -> DashboardStats:
+    """聚合统计系统核心指标。"""
+
+    # ── Sessions ────────────────────────────────────────────
+    session_total = await db.scalar(
+        select(func.count()).select_from(SessionRecord)
+    ) or 0
+
+    # 按 channel 分组
+    channel_rows = (
+        await db.execute(
+            select(SessionRecord.channel, func.count())
+            .group_by(SessionRecord.channel)
+        )
+    ).all()
+    sessions_by_channel = {row[0]: row[1] for row in channel_rows}
+
+    # 按 model_name 分组
+    model_rows = (
+        await db.execute(
+            select(SessionRecord.model_name, func.count())
+            .where(SessionRecord.model_name.isnot(None))
+            .group_by(SessionRecord.model_name)
+        )
+    ).all()
+    models_in_use = {row[0]: row[1] for row in model_rows}
+
+    # context_tokens 总和
+    total_tokens = await db.scalar(
+        select(func.coalesce(func.sum(SessionRecord.context_tokens), 0))
+    ) or 0
+
+    # ── Messages ────────────────────────────────────────────
+    total_messages = await db.scalar(
+        select(func.count()).select_from(MemoryRecord)
+    ) or 0
+
+    # ── Tool calls ──────────────────────────────────────────
+    total_tool_calls = await db.scalar(
+        select(func.count()).select_from(ToolCallLog)
+    ) or 0
+
+    # 按 tool_name 分组 Top 10
+    tool_name_rows = (
+        await db.execute(
+            select(ToolCallLog.tool_name, func.count().label("cnt"))
+            .group_by(ToolCallLog.tool_name)
+            .order_by(func.count().desc())
+            .limit(10)
+        )
+    ).all()
+    tool_calls_by_name = {row[0]: row[1] for row in tool_name_rows}
+
+    # 错误数
+    tool_errors = await db.scalar(
+        select(func.count())
+        .select_from(ToolCallLog)
+        .where(ToolCallLog.error.isnot(None))
+    ) or 0
+
+    # 平均耗时
+    avg_tool_duration = await db.scalar(
+        select(func.coalesce(func.avg(ToolCallLog.duration_ms), 0.0))
+    ) or 0.0
+
+    # ── Skills ──────────────────────────────────────────────
+    total_skills = await db.scalar(
+        select(func.count()).select_from(SkillRecord)
+    ) or 0
+
+    enabled_skills = await db.scalar(
+        select(func.count())
+        .select_from(SkillRecord)
+        .where(SkillRecord.enabled.is_(True))
+    ) or 0
+
+    # ── Cron ────────────────────────────────────────────────
+    total_cron_jobs = await db.scalar(
+        select(func.count()).select_from(CronJob)
+    ) or 0
+
+    enabled_cron_jobs = await db.scalar(
+        select(func.count())
+        .select_from(CronJob)
+        .where(CronJob.enabled.is_(True))
+    ) or 0
+
+    cron_executions = await db.scalar(
+        select(func.count()).select_from(CronJobExecution)
+    ) or 0
+
+    cron_failures = await db.scalar(
+        select(func.count())
+        .select_from(CronJobExecution)
+        .where(CronJobExecution.status == "failed")
+    ) or 0
+
+    # ── SubAgent tasks ──────────────────────────────────────
+    sub_agent_tasks = await db.scalar(
+        select(func.count()).select_from(SubAgentTask)
+    ) or 0
+
+    sub_agent_failures = await db.scalar(
+        select(func.count())
+        .select_from(SubAgentTask)
+        .where(SubAgentTask.status == "failed")
+    ) or 0
+
+    # ── Total errors ────────────────────────────────────────
+    total_errors = tool_errors + cron_failures + sub_agent_failures
+
+    return DashboardStats(
+        total_sessions=session_total,
+        sessions_by_channel=sessions_by_channel,
+        total_messages=total_messages,
+        total_tokens=total_tokens,
+        models_in_use=models_in_use,
+        total_tool_calls=total_tool_calls,
+        tool_calls_by_name=tool_calls_by_name,
+        tool_errors=tool_errors,
+        avg_tool_duration_ms=round(float(avg_tool_duration), 1),
+        total_skills=total_skills,
+        enabled_skills=enabled_skills,
+        total_cron_jobs=total_cron_jobs,
+        enabled_cron_jobs=enabled_cron_jobs,
+        cron_executions=cron_executions,
+        cron_failures=cron_failures,
+        total_errors=total_errors,
+        sub_agent_tasks=sub_agent_tasks,
+        sub_agent_failures=sub_agent_failures,
+    )

--- a/backend/agentpal/api/v1/router.py
+++ b/backend/agentpal/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from agentpal.api.v1.endpoints import agent, channel, config, cron, session, skills, sub_agents, tools, workspace
+from agentpal.api.v1.endpoints import agent, channel, config, cron, dashboard, session, skills, sub_agents, tools, workspace
 
 router = APIRouter()
 router.include_router(agent.router, prefix="/agent", tags=["agent"])
@@ -12,3 +12,4 @@ router.include_router(workspace.router, prefix="/workspace", tags=["workspace"])
 router.include_router(config.router, prefix="/config", tags=["config"])
 router.include_router(sub_agents.router, prefix="/sub-agents", tags=["sub-agents"])
 router.include_router(cron.router, prefix="/cron", tags=["cron"])
+router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import ToolsPage from "./pages/ToolsPage";
 import SkillsPage from "./pages/SkillsPage";
 import WorkspacePage from "./pages/WorkspacePage";
 import SessionsPage from "./pages/SessionsPage";
+import DashboardPage from "./pages/DashboardPage";
 import Layout from "./components/Layout";
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
           <Route path="/tasks" element={<TasksPage />} />
           <Route path="/sessions" element={<SessionsPage />} />
           <Route path="/workspace" element={<WorkspacePage />} />
+          <Route path="/dashboard" element={<DashboardPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -377,4 +377,32 @@ export async function getCronExecutionDetail(executionId: string): Promise<CronE
   return data;
 }
 
+// ── Dashboard API ─────────────────────────────────────────
+
+export interface DashboardStats {
+  total_sessions: number;
+  sessions_by_channel: Record<string, number>;
+  total_messages: number;
+  total_tokens: number;
+  models_in_use: Record<string, number>;
+  total_tool_calls: number;
+  tool_calls_by_name: Record<string, number>;
+  tool_errors: number;
+  avg_tool_duration_ms: number;
+  total_skills: number;
+  enabled_skills: number;
+  total_cron_jobs: number;
+  enabled_cron_jobs: number;
+  cron_executions: number;
+  cron_failures: number;
+  total_errors: number;
+  sub_agent_tasks: number;
+  sub_agent_failures: number;
+}
+
+export async function getDashboardStats(): Promise<DashboardStats> {
+  const { data } = await api.get<DashboardStats>("/dashboard/stats");
+  return data;
+}
+
 export default api;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { Link, Outlet, useLocation } from "react-router-dom";
-import { MessageCircle, ListTodo, Wrench, Puzzle, FolderClosed, MessagesSquare } from "lucide-react";
+import { MessageCircle, ListTodo, Wrench, Puzzle, FolderClosed, MessagesSquare, BarChart3 } from "lucide-react";
 import clsx from "clsx";
 import NimoIcon from "./NimoIcon";
 
@@ -12,6 +12,7 @@ export default function Layout() {
     { to: "/skills",    icon: Puzzle,          label: "技能" },
     { to: "/tasks",     icon: ListTodo,        label: "任务" },
     { to: "/workspace", icon: FolderClosed,    label: "工作空间" },
+    { to: "/dashboard", icon: BarChart3,        label: "监控" },
   ];
 
   return (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,382 @@
+import { useQuery } from "@tanstack/react-query";
+import { RefreshCw, Loader2 } from "lucide-react";
+import clsx from "clsx";
+import { getDashboardStats, type DashboardStats } from "../api";
+
+// ── 数字格式化 ──────────────────────────────────────────────
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toString();
+}
+
+// ── 颜色配置 ─────────────────────────────────────────────────
+
+const BAR_COLORS = [
+  "bg-violet-500",
+  "bg-blue-500",
+  "bg-cyan-500",
+  "bg-emerald-500",
+  "bg-amber-500",
+  "bg-rose-500",
+  "bg-indigo-500",
+  "bg-teal-500",
+  "bg-orange-500",
+  "bg-pink-500",
+];
+
+// ── 指标卡片组件 ──────────────────────────────────────────────
+
+function StatCard({
+  icon,
+  label,
+  value,
+  gradient,
+}: {
+  icon: string;
+  label: string;
+  value: string | number;
+  gradient: string;
+}) {
+  return (
+    <div
+      className={clsx(
+        "relative overflow-hidden rounded-2xl p-5 text-white shadow-lg",
+        gradient
+      )}
+    >
+      <div className="absolute right-3 top-3 text-3xl opacity-20">{icon}</div>
+      <p className="text-sm font-medium opacity-90">{label}</p>
+      <p className="mt-1 text-3xl font-bold tracking-tight">
+        {typeof value === "number" ? formatNumber(value) : value}
+      </p>
+    </div>
+  );
+}
+
+// ── 分布条形图组件 ────────────────────────────────────────────
+
+function DistributionCard({
+  title,
+  icon,
+  data,
+}: {
+  title: string;
+  icon: string;
+  data: Record<string, number>;
+}) {
+  const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
+  const maxVal = Math.max(...entries.map(([, v]) => v), 1);
+
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+        <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-700">
+          <span>{icon}</span> {title}
+        </h3>
+        <p className="text-sm text-gray-400">暂无数据</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+      <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-700">
+        <span>{icon}</span> {title}
+      </h3>
+      <div className="space-y-3">
+        {entries.map(([name, count], i) => {
+          const pct = (count / maxVal) * 100;
+          const total = entries.reduce((s, [, v]) => s + v, 0);
+          const share = total > 0 ? ((count / total) * 100).toFixed(0) : "0";
+          return (
+            <div key={name}>
+              <div className="mb-1 flex items-center justify-between text-xs">
+                <span className="font-medium text-gray-600">{name}</span>
+                <span className="text-gray-400">
+                  {count} <span className="text-gray-300">({share}%)</span>
+                </span>
+              </div>
+              <div className="h-2.5 w-full overflow-hidden rounded-full bg-gray-100">
+                <div
+                  className={clsx(
+                    "h-full rounded-full transition-all duration-500",
+                    BAR_COLORS[i % BAR_COLORS.length]
+                  )}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── 工具排行榜组件 ────────────────────────────────────────────
+
+function ToolRankingCard({
+  data,
+}: {
+  data: Record<string, number>;
+}) {
+  const entries = Object.entries(data).sort((a, b) => b[1] - a[1]);
+  const maxVal = Math.max(...entries.map(([, v]) => v), 1);
+
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+        <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-700">
+          <span>🏆</span> 工具调用 Top 10
+        </h3>
+        <p className="text-sm text-gray-400">暂无数据</p>
+      </div>
+    );
+  }
+
+  const rankGradients = [
+    "from-amber-400 to-yellow-500",
+    "from-gray-300 to-gray-400",
+    "from-amber-600 to-amber-700",
+  ];
+
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+      <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-700">
+        <span>🏆</span> 工具调用 Top 10
+      </h3>
+      <div className="space-y-2.5">
+        {entries.map(([name, count], i) => {
+          const pct = (count / maxVal) * 100;
+          return (
+            <div key={name} className="flex items-center gap-3">
+              <span
+                className={clsx(
+                  "flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full text-xs font-bold",
+                  i < 3
+                    ? `bg-gradient-to-br ${rankGradients[i]} text-white`
+                    : "bg-gray-100 text-gray-500"
+                )}
+              >
+                {i + 1}
+              </span>
+              <div className="flex-1">
+                <div className="mb-0.5 flex items-center justify-between text-xs">
+                  <span className="font-mono font-medium text-gray-700">
+                    {name}
+                  </span>
+                  <span className="text-gray-400">{count}</span>
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-gray-100">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-violet-500 to-purple-500 transition-all duration-500"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── 系统状态面板组件 ──────────────────────────────────────────
+
+function SystemStatusCard({ stats }: { stats: DashboardStats }) {
+  const items = [
+    {
+      icon: "🧩",
+      label: "技能",
+      detail: `${stats.total_skills} 已安装 / ${stats.enabled_skills} 启用`,
+      ok: true,
+    },
+    {
+      icon: "⏰",
+      label: "定时任务",
+      detail: `${stats.total_cron_jobs} 个 / ${stats.enabled_cron_jobs} 启用`,
+      ok: true,
+    },
+    {
+      icon: "📋",
+      label: "Cron 执行",
+      detail: `${stats.cron_executions - stats.cron_failures} 成功 / ${stats.cron_failures} 失败`,
+      ok: stats.cron_failures === 0,
+    },
+    {
+      icon: "🤖",
+      label: "SubAgent",
+      detail: `${stats.sub_agent_tasks - stats.sub_agent_failures} 完成 / ${stats.sub_agent_failures} 失败`,
+      ok: stats.sub_agent_failures === 0,
+    },
+    {
+      icon: "🔧",
+      label: "工具耗时",
+      detail: `avg ${stats.avg_tool_duration_ms.toFixed(0)}ms`,
+      ok: true,
+    },
+  ];
+
+  return (
+    <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+      <h3 className="mb-4 flex items-center gap-2 text-sm font-semibold text-gray-700">
+        <span>📡</span> 系统状态
+      </h3>
+      <div className="space-y-3">
+        {items.map((item) => (
+          <div
+            key={item.label}
+            className="flex items-center justify-between rounded-xl bg-gray-50 px-4 py-3"
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-lg">{item.icon}</span>
+              <span className="text-sm font-medium text-gray-700">
+                {item.label}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-500">{item.detail}</span>
+              <span
+                className={clsx(
+                  "h-2 w-2 rounded-full",
+                  item.ok ? "bg-emerald-400" : "bg-red-400"
+                )}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── 主页面 ──────────────────────────────────────────────────
+
+export default function DashboardPage() {
+  const {
+    data: stats,
+    isLoading,
+    isFetching,
+    refetch,
+    dataUpdatedAt,
+  } = useQuery<DashboardStats>({
+    queryKey: ["dashboard-stats"],
+    queryFn: getDashboardStats,
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  });
+
+  const lastUpdated = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString("zh-CN")
+    : "--:--:--";
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-6xl px-6 py-8">
+        {/* Header */}
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-800">
+              <span className="mr-2">⚡</span>系统监控
+            </h1>
+            <p className="mt-1 text-sm text-gray-400">
+              实时系统运行指标概览
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-gray-400">
+              更新于 {lastUpdated}
+            </span>
+            <button
+              onClick={() => refetch()}
+              disabled={isFetching}
+              className={clsx(
+                "flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-50",
+                isFetching && "opacity-50"
+              )}
+            >
+              <RefreshCw
+                size={14}
+                className={clsx(isFetching && "animate-spin")}
+              />
+              刷新
+            </button>
+          </div>
+        </div>
+
+        {/* Loading state */}
+        {isLoading && (
+          <div className="flex h-64 items-center justify-center">
+            <Loader2 size={32} className="animate-spin text-gray-300" />
+          </div>
+        )}
+
+        {/* Dashboard content */}
+        {stats && (
+          <div className="space-y-6">
+            {/* ── Top 指标卡片 ─────────────────────────────── */}
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+              <StatCard
+                icon="📊"
+                label="会话"
+                value={stats.total_sessions}
+                gradient="bg-gradient-to-br from-violet-500 to-blue-600"
+              />
+              <StatCard
+                icon="💬"
+                label="消息"
+                value={stats.total_messages}
+                gradient="bg-gradient-to-br from-blue-500 to-cyan-500"
+              />
+              <StatCard
+                icon="🔤"
+                label="Tokens"
+                value={stats.total_tokens}
+                gradient="bg-gradient-to-br from-cyan-500 to-emerald-500"
+              />
+              <StatCard
+                icon="🔧"
+                label="工具调用"
+                value={stats.total_tool_calls}
+                gradient="bg-gradient-to-br from-orange-400 to-amber-500"
+              />
+              <StatCard
+                icon={stats.total_errors === 0 ? "✅" : "⚠️"}
+                label="错误"
+                value={stats.total_errors}
+                gradient={
+                  stats.total_errors === 0
+                    ? "bg-gradient-to-br from-emerald-400 to-green-500"
+                    : "bg-gradient-to-br from-red-500 to-pink-500"
+                }
+              />
+            </div>
+
+            {/* ── 中部：渠道分布 + 模型使用 ───────────────── */}
+            <div className="grid gap-4 md:grid-cols-2">
+              <DistributionCard
+                title="渠道分布"
+                icon="📡"
+                data={stats.sessions_by_channel}
+              />
+              <DistributionCard
+                title="模型使用"
+                icon="🧠"
+                data={stats.models_in_use}
+              />
+            </div>
+
+            {/* ── 底部：工具排行 + 系统状态 ───────────────── */}
+            <div className="grid gap-4 md:grid-cols-2">
+              <ToolRankingCard data={stats.tool_calls_by_name} />
+              <SystemStatusCard stats={stats} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 后端新增 `GET /api/v1/dashboard/stats` 聚合统计接口，从 sessions、memory_records、tool_call_logs、skills、cron_jobs、cron_job_executions、sub_agent_tasks 7 张表聚合 18 项指标
- 前端新增 Dashboard 页面：渐变指标卡片（会话/消息/Tokens/工具调用/错误）、渠道分布 & 模型使用彩色条形图、工具调用 Top 10 排行榜、系统状态面板
- 侧边栏添加"监控"导航入口（BarChart3 图标），前端路由注册 `/dashboard`，30 秒自动刷新 + 手动刷新按钮

## Test plan
- [ ] `curl http://localhost:8099/api/v1/dashboard/stats` 返回正确 JSON 聚合数据
- [ ] 前端 `/dashboard` 页面正常渲染所有指标卡片和图表
- [ ] 侧边栏"监控"图标正常显示和高亮
- [ ] 30 秒自动刷新 + 手动刷新按钮正常工作
- [ ] 现有 246 个后端测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)