### PR TITLE
feat: WebSocket 实时通知系统 — 替换轮询，事件驱动刷新

### DIFF
--- a/backend/agentpal/agents/sub_agent.py
+++ b/backend/agentpal/agents/sub_agent.py
@@ -378,6 +378,34 @@ class SubAgent(BaseAgent):
         except Exception:
             pass
 
+        # 任务终态时发布 WebSocket 通知
+        if status in (TaskStatus.DONE, TaskStatus.FAILED):
+            try:
+                from agentpal.services.notification_bus import (
+                    Notification,
+                    NotificationType,
+                    notification_bus,
+                )
+
+                ntype = (
+                    NotificationType.SUBAGENT_TASK_DONE
+                    if status == TaskStatus.DONE
+                    else NotificationType.SUBAGENT_TASK_FAILED
+                )
+                await notification_bus.publish(
+                    Notification(
+                        type=ntype,
+                        timestamp=datetime.now(timezone.utc).isoformat(),
+                        payload={
+                            "task_id": self._task.id,
+                            "agent_name": self._task.agent_name,
+                            "status": status.value,
+                        },
+                    )
+                )
+            except Exception:
+                pass  # 通知失败不影响主流程
+
     def _log(self, event_type: str, data: dict[str, Any]) -> None:
         """向执行日志追加一条记录。"""
         self._execution_log.append({

--- a/backend/agentpal/api/v1/endpoints/notifications.py
+++ b/backend/agentpal/api/v1/endpoints/notifications.py
@@ -1,0 +1,52 @@
+"""WebSocket 通知端点 — 向前端推送系统事件。
+
+路径：/api/v1/notifications/ws
+协议：WebSocket
+消息格式：JSON（Notification.model_dump()）
+心跳：每 30 秒无消息时发送 {"type": "ping"}
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from loguru import logger
+
+from agentpal.services.notification_bus import notification_bus
+
+router = APIRouter()
+
+_HEARTBEAT_INTERVAL = 30.0  # 秒
+
+
+@router.websocket("/ws")
+async def notifications_ws(ws: WebSocket) -> None:
+    """WebSocket 端点：订阅全局通知。"""
+    await ws.accept()
+    queue = notification_bus.subscribe()
+    logger.debug(
+        "WS notifications 已连接 (subscribers={})",
+        notification_bus.subscriber_count,
+    )
+
+    try:
+        while True:
+            try:
+                data = await asyncio.wait_for(
+                    queue.get(), timeout=_HEARTBEAT_INTERVAL
+                )
+                await ws.send_json(data)
+            except asyncio.TimeoutError:
+                # 超时无消息，发送心跳保持连接
+                await ws.send_json({"type": "ping"})
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        logger.debug("WS notifications 异常断开: {}", e)
+    finally:
+        notification_bus.unsubscribe(queue)
+        logger.debug(
+            "WS notifications 已断开 (subscribers={})",
+            notification_bus.subscriber_count,
+        )

--- a/backend/agentpal/api/v1/router.py
+++ b/backend/agentpal/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from agentpal.api.v1.endpoints import agent, channel, config, cron, dashboard, providers, session, skills, sub_agents, tools, workspace
+from agentpal.api.v1.endpoints import agent, channel, config, cron, dashboard, notifications, providers, session, skills, sub_agents, tools, workspace
 
 router = APIRouter()
 router.include_router(agent.router, prefix="/agent", tags=["agent"])
@@ -14,3 +14,4 @@ router.include_router(providers.router, prefix="/providers", tags=["providers"])
 router.include_router(sub_agents.router, prefix="/sub-agents", tags=["sub-agents"])
 router.include_router(cron.router, prefix="/cron", tags=["cron"])
 router.include_router(dashboard.router, prefix="/dashboard", tags=["dashboard"])
+router.include_router(notifications.router, prefix="/notifications", tags=["notifications"])

--- a/backend/agentpal/services/cron_scheduler.py
+++ b/backend/agentpal/services/cron_scheduler.py
@@ -362,6 +362,28 @@ class CronScheduler:
 
                 logger.info(f"定时任务完成: {job_name} (ID={job_id})")
 
+                # 发布 WebSocket 通知
+                try:
+                    from agentpal.services.notification_bus import (
+                        Notification,
+                        NotificationType,
+                        notification_bus,
+                    )
+
+                    await notification_bus.publish(
+                        Notification(
+                            type=NotificationType.CRON_EXECUTION_DONE,
+                            timestamp=datetime.now(timezone.utc).isoformat(),
+                            payload={
+                                "job_id": job_id,
+                                "job_name": job_name,
+                                "execution_id": execution.id,
+                            },
+                        )
+                    )
+                except Exception:
+                    pass  # 通知失败不影响主流程
+
             except Exception as e:
                 logger.error(f"定时任务失败: {job_name} (ID={job_id}): {e}")
                 await mgr.finish_execution(
@@ -371,6 +393,28 @@ class CronScheduler:
                     execution_log=execution_log,
                 )
                 await db.commit()
+
+                # 发布 WebSocket 通知（失败）
+                try:
+                    from agentpal.services.notification_bus import (
+                        Notification,
+                        NotificationType,
+                        notification_bus,
+                    )
+
+                    await notification_bus.publish(
+                        Notification(
+                            type=NotificationType.CRON_EXECUTION_FAILED,
+                            timestamp=datetime.now(timezone.utc).isoformat(),
+                            payload={
+                                "job_id": job_id,
+                                "job_name": job_name,
+                                "error": str(e)[:200],
+                            },
+                        )
+                    )
+                except Exception:
+                    pass  # 通知失败不影响主流程
 
     async def _ensure_heartbeat_job(self) -> None:
         """确保 heartbeat 定时任务存在（幂等）。

--- a/backend/agentpal/services/notification_bus.py
+++ b/backend/agentpal/services/notification_bus.py
@@ -1,0 +1,89 @@
+"""NotificationBus — 全局通知事件总线。
+
+向 WebSocket 订阅方广播系统事件（SubAgent 任务完成、Cron 执行结果等）。
+
+使用方式：
+    # 订阅者（WebSocket 端点）
+    queue = notification_bus.subscribe()
+    notification = await asyncio.wait_for(queue.get(), timeout=30.0)
+
+    # 发布者（SubAgent / CronScheduler）
+    await notification_bus.publish(Notification(
+        type=NotificationType.SUBAGENT_TASK_DONE,
+        payload={"task_id": "...", "status": "done"},
+    ))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class NotificationType(str, Enum):
+    """通知类型枚举。"""
+
+    SUBAGENT_TASK_DONE = "subagent_task_done"
+    SUBAGENT_TASK_FAILED = "subagent_task_failed"
+    CRON_EXECUTION_DONE = "cron_execution_done"
+    CRON_EXECUTION_FAILED = "cron_execution_failed"
+
+
+class Notification(BaseModel):
+    """通知消息模型。"""
+
+    type: NotificationType
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat()
+    )
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class NotificationBus:
+    """全局通知事件总线。
+
+    基于 asyncio.Queue 的 fan-out pub/sub。
+    每个 WebSocket 连接调用 subscribe() 获取一个独立队列，
+    发布者通过 publish() 向所有队列广播消息。
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: list[asyncio.Queue[dict[str, Any]]] = []
+
+    def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
+        """订阅通知，返回消息队列。
+
+        队列 maxsize=256，防止慢消费者拖累整个系统。
+        """
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=256)
+        self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
+        """取消订阅，WebSocket 断开时调用。"""
+        with contextlib.suppress(ValueError):
+            self._subscribers.remove(queue)
+
+    async def publish(self, notification: Notification) -> None:
+        """向所有订阅者广播通知。
+
+        队列满时丢弃本次事件（防止慢速客户端阻塞发布者）。
+        """
+        data = notification.model_dump()
+        for q in list(self._subscribers):
+            with contextlib.suppress(asyncio.QueueFull):
+                q.put_nowait(data)
+
+    @property
+    def subscriber_count(self) -> int:
+        """当前订阅者数量（调试用）。"""
+        return len(self._subscribers)
+
+
+# 全局单例
+notification_bus = NotificationBus()

--- a/backend/tests/integration/test_notifications_ws.py
+++ b/backend/tests/integration/test_notifications_ws.py
@@ -1,0 +1,113 @@
+"""WebSocket 通知端点集成测试。
+
+使用 Starlette TestClient 的 websocket_connect() 测试 WS 连接、消息接收、心跳。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+import time
+
+import pytest
+from starlette.testclient import TestClient
+
+from agentpal.database import get_db, get_db_standalone
+from agentpal.main import create_app
+from agentpal.services.notification_bus import (
+    Notification,
+    NotificationType,
+    notification_bus,
+)
+
+# ── 测试数据库覆盖（复用现有模式）─────────────────────────────
+
+
+@pytest.fixture
+def test_app():
+    """创建测试应用（同步 fixture，配合 Starlette TestClient）。"""
+    app = create_app()
+
+    # 注意：WebSocket 测试用 Starlette TestClient，不需要真正的 DB 操作，
+    # 但仍需覆盖依赖以避免连接真实数据库。
+    async def override_db():
+        yield None
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_db_standalone] = override_db
+    return app
+
+
+# ── WebSocket 端点测试 ────────────────────────────────────────
+
+
+class TestNotificationsWebSocket:
+    """WebSocket /api/v1/notifications/ws 端点测试。"""
+
+    def test_ws_connect_and_receive_ping(self, test_app):
+        """连接成功后，超时时应收到 ping 心跳。"""
+        # 使用极短的心跳间隔来加速测试
+        import agentpal.api.v1.endpoints.notifications as notifications_mod
+
+        original_interval = notifications_mod._HEARTBEAT_INTERVAL
+        notifications_mod._HEARTBEAT_INTERVAL = 0.5  # 500ms
+
+        try:
+            client = TestClient(test_app)
+            with client.websocket_connect("/api/v1/notifications/ws") as ws:
+                data = ws.receive_json(mode="text")
+                assert data["type"] == "ping"
+        finally:
+            notifications_mod._HEARTBEAT_INTERVAL = original_interval
+
+    def test_ws_receive_notification(self, test_app):
+        """发布通知后，WebSocket 客户端应收到消息。"""
+        import agentpal.api.v1.endpoints.notifications as notifications_mod
+
+        original_interval = notifications_mod._HEARTBEAT_INTERVAL
+        notifications_mod._HEARTBEAT_INTERVAL = 5.0  # 足够长，不会收到 ping
+
+        try:
+            client = TestClient(test_app)
+            with client.websocket_connect("/api/v1/notifications/ws") as ws:
+                # 在另一个线程中发布通知（TestClient 在后台线程运行 ASGI app）
+                def publish_later():
+                    time.sleep(0.3)
+                    # TestClient 运行在自己的 event loop 里，
+                    # 但 notification_bus 的 put_nowait 是线程安全的
+                    notif = Notification(
+                        type=NotificationType.SUBAGENT_TASK_DONE,
+                        payload={"task_id": "test-123", "status": "done"},
+                    )
+                    # 直接调用 put_nowait 绕过 async
+                    data = notif.model_dump()
+                    for q in list(notification_bus._subscribers):
+                        with contextlib.suppress(asyncio.QueueFull):
+                            q.put_nowait(data)
+
+                t = threading.Thread(target=publish_later)
+                t.start()
+
+                data = ws.receive_json(mode="text")
+                assert data["type"] == "subagent_task_done"
+                assert data["payload"]["task_id"] == "test-123"
+
+                t.join()
+        finally:
+            notifications_mod._HEARTBEAT_INTERVAL = original_interval
+
+    def test_ws_subscriber_cleanup_on_disconnect(self, test_app):
+        """WebSocket 断开后，订阅者应被清理。"""
+        initial_count = notification_bus.subscriber_count
+
+        client = TestClient(test_app)
+        with client.websocket_connect("/api/v1/notifications/ws"):
+            # 连接期间，订阅者计数应增加
+            # 注意：由于 TestClient 在后台线程运行，可能需要短暂等待
+            time.sleep(0.1)
+            assert notification_bus.subscriber_count >= initial_count + 1
+
+        # 断开后等待清理
+        time.sleep(0.2)
+        assert notification_bus.subscriber_count == initial_count

--- a/backend/tests/unit/test_notification_bus.py
+++ b/backend/tests/unit/test_notification_bus.py
@@ -1,0 +1,138 @@
+"""NotificationBus 单元测试。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agentpal.services.notification_bus import (
+    Notification,
+    NotificationBus,
+    NotificationType,
+)
+
+
+def _make_notification(
+    ntype: NotificationType = NotificationType.SUBAGENT_TASK_DONE,
+    **payload: object,
+) -> Notification:
+    return Notification(type=ntype, payload=payload or {"task_id": "t1"})
+
+
+class TestNotificationBus:
+    """NotificationBus 核心行为。"""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_and_publish(self):
+        """订阅后能收到发布的消息。"""
+        bus = NotificationBus()
+        queue = bus.subscribe()
+
+        notif = _make_notification()
+        await bus.publish(notif)
+
+        data = queue.get_nowait()
+        assert data["type"] == NotificationType.SUBAGENT_TASK_DONE.value
+        assert data["payload"]["task_id"] == "t1"
+        assert "timestamp" in data
+
+    @pytest.mark.asyncio
+    async def test_multi_subscriber_broadcast(self):
+        """多个订阅者都能收到同一条消息。"""
+        bus = NotificationBus()
+        q1 = bus.subscribe()
+        q2 = bus.subscribe()
+        q3 = bus.subscribe()
+
+        await bus.publish(_make_notification())
+
+        for q in (q1, q2, q3):
+            data = q.get_nowait()
+            assert data["type"] == NotificationType.SUBAGENT_TASK_DONE.value
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe(self):
+        """取消订阅后不再收到消息。"""
+        bus = NotificationBus()
+        q1 = bus.subscribe()
+        q2 = bus.subscribe()
+
+        bus.unsubscribe(q1)
+
+        await bus.publish(_make_notification())
+
+        assert q1.empty()
+        assert not q2.empty()
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_nonexistent_queue(self):
+        """取消一个未订阅的队列不报错。"""
+        bus = NotificationBus()
+        random_queue: asyncio.Queue = asyncio.Queue()
+        bus.unsubscribe(random_queue)  # 不应抛异常
+
+    @pytest.mark.asyncio
+    async def test_slow_consumer_drop(self):
+        """慢消费者（队列满）时丢弃消息，不阻塞发布。"""
+        bus = NotificationBus()
+        # 用 maxsize=1 的队列模拟慢消费者
+        small_q: asyncio.Queue = asyncio.Queue(maxsize=1)
+        bus._subscribers.append(small_q)
+
+        # 第一条应成功入队
+        await bus.publish(_make_notification(task_id="first"))
+        assert small_q.qsize() == 1
+
+        # 第二条应被丢弃（队列满），不抛异常
+        await bus.publish(_make_notification(task_id="second"))
+        assert small_q.qsize() == 1  # 仍然是 1
+
+        # 取出的应该是第一条
+        data = small_q.get_nowait()
+        assert data["payload"]["task_id"] == "first"
+
+    @pytest.mark.asyncio
+    async def test_publish_no_subscribers(self):
+        """没有订阅者时发布不报错。"""
+        bus = NotificationBus()
+        await bus.publish(_make_notification())  # 不应抛异常
+
+    @pytest.mark.asyncio
+    async def test_subscriber_count(self):
+        """subscriber_count 属性正确反映当前订阅者数量。"""
+        bus = NotificationBus()
+        assert bus.subscriber_count == 0
+
+        q1 = bus.subscribe()
+        assert bus.subscriber_count == 1
+
+        q2 = bus.subscribe()
+        assert bus.subscriber_count == 2
+
+        bus.unsubscribe(q1)
+        assert bus.subscriber_count == 1
+
+        bus.unsubscribe(q2)
+        assert bus.subscriber_count == 0
+
+    @pytest.mark.asyncio
+    async def test_notification_types(self):
+        """所有 NotificationType 都可以正常发布和接收。"""
+        bus = NotificationBus()
+        queue = bus.subscribe()
+
+        for ntype in NotificationType:
+            await bus.publish(Notification(type=ntype, payload={"t": ntype.value}))
+
+        for ntype in NotificationType:
+            data = queue.get_nowait()
+            assert data["type"] == ntype.value
+            assert data["payload"]["t"] == ntype.value
+
+    @pytest.mark.asyncio
+    async def test_notification_model_defaults(self):
+        """Notification 模型的默认值正确。"""
+        notif = Notification(type=NotificationType.CRON_EXECUTION_DONE)
+        assert notif.timestamp  # 非空
+        assert notif.payload == {}

--- a/frontend/src/hooks/useCron.ts
+++ b/frontend/src/hooks/useCron.ts
@@ -61,7 +61,7 @@ export function useCronExecutions(jobId: string | undefined) {
     queryKey: ["cron-executions", jobId],
     queryFn: () => listCronExecutions(jobId!, 20),
     enabled: !!jobId,
-    refetchInterval: 10000,
+    staleTime: 30_000,
   });
 }
 

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,108 @@
+/**
+ * useNotifications — WebSocket 通知订阅 Hook。
+ *
+ * 连接后端 /api/v1/notifications/ws，收到推送后按类型
+ * invalidate 对应的 React Query 缓存。
+ *
+ * 纯副作用 Hook，不返回 state。
+ */
+
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+// ── 通知类型到 React Query Key 的映射 ──────────────────────
+
+const INVALIDATION_MAP: Record<string, string[][]> = {
+  subagent_task_done: [["tasks"], ["dashboard-stats"]],
+  subagent_task_failed: [["tasks"], ["dashboard-stats"]],
+  cron_execution_done: [["cron-executions"], ["cron-jobs"], ["dashboard-stats"]],
+  cron_execution_failed: [
+    ["cron-executions"],
+    ["cron-jobs"],
+    ["dashboard-stats"],
+  ],
+};
+
+// ── 退避计算 ──────────────────────────────────────────────
+
+const BACKOFF_BASE = 1000; // 1 秒
+const BACKOFF_MAX = 30_000; // 30 秒
+
+function getBackoff(attempt: number): number {
+  return Math.min(BACKOFF_BASE * 2 ** attempt, BACKOFF_MAX);
+}
+
+// ── 构建 WebSocket URL ────────────────────────────────────
+
+function buildWsUrl(): string {
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${window.location.host}/api/v1/notifications/ws`;
+}
+
+// ── Hook ──────────────────────────────────────────────────
+
+export function useNotifications(): void {
+  const queryClient = useQueryClient();
+  const attemptRef = useRef(0);
+  const wsRef = useRef<WebSocket | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let unmounted = false;
+
+    function connect() {
+      if (unmounted) return;
+
+      const ws = new WebSocket(buildWsUrl());
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        attemptRef.current = 0; // 连接成功，重置退避
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === "ping") return; // 忽略心跳
+
+          const keys = INVALIDATION_MAP[data.type];
+          if (keys) {
+            for (const queryKey of keys) {
+              queryClient.invalidateQueries({ queryKey });
+            }
+          }
+        } catch {
+          // 忽略解析错误
+        }
+      };
+
+      ws.onclose = () => {
+        wsRef.current = null;
+        if (unmounted) return;
+
+        // 指数退避重连
+        const delay = getBackoff(attemptRef.current);
+        attemptRef.current += 1;
+        timerRef.current = setTimeout(connect, delay);
+      };
+
+      ws.onerror = () => {
+        // onerror 之后会触发 onclose，在 onclose 中处理重连
+      };
+    }
+
+    connect();
+
+    return () => {
+      unmounted = true;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [queryClient]);
+}

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -5,7 +5,6 @@ export function useTasks(params?: TaskListParams) {
   return useQuery<TaskListResponse>({
     queryKey: ["tasks", params],
     queryFn: () => listTasks(params),
-    refetchInterval: 5000,
-    staleTime: 3000,
+    staleTime: 30_000,
   });
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
+import { NotificationProvider } from "./providers/NotificationProvider";
 import "./index.css";
 
 const queryClient = new QueryClient({
@@ -13,7 +14,9 @@ const queryClient = new QueryClient({
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <NotificationProvider>
+        <App />
+      </NotificationProvider>
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -313,8 +313,7 @@ export default function DashboardPage() {
   } = useQuery<DashboardStats>({
     queryKey: ["dashboard-stats"],
     queryFn: getDashboardStats,
-    refetchInterval: 30_000,
-    staleTime: 10_000,
+    staleTime: 60_000,
   });
 
   const lastUpdated = dataUpdatedAt

--- a/frontend/src/providers/NotificationProvider.tsx
+++ b/frontend/src/providers/NotificationProvider.tsx
@@ -1,0 +1,14 @@
+/**
+ * NotificationProvider — 全局 WebSocket 通知订阅。
+ *
+ * 在 QueryClientProvider 内、App 外包裹，确保 useQueryClient 可用。
+ * 仅调用 useNotifications() 副作用，不添加额外 DOM 节点。
+ */
+
+import type { ReactNode } from "react";
+import { useNotifications } from "../hooks/useNotifications";
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  useNotifications();
+  return <>{children}</>;
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
   server: {
     port: 3000,
     proxy: {
+      "/api/v1/notifications/ws": {
+        target: process.env.VITE_API_BASE_URL || "http://localhost:8099",
+        ws: true,
+      },
       "/api": {
         target: process.env.VITE_API_BASE_URL || "http://localhost:8099",
         changeOrigin: true,


### PR DESCRIPTION
## Summary

- **新增 `NotificationBus`**（`backend/agentpal/services/notification_bus.py`）：基于 `asyncio.Queue` 的 fan-out pub/sub 总线，支持 256 消息缓冲、慢消费者丢弃、指数退避重连
- **新增 WebSocket 端点** `GET /api/v1/notifications/ws`（`notifications.py`）：每 30 秒无消息时发送心跳 `{"type": "ping"}` 保持连接
- **SubAgent & CronScheduler 集成**：任务完成/失败时通过 `notification_bus.publish()` 广播事件，失败不影响主流程
- **前端 `useNotifications` Hook + `NotificationProvider`**：连接 WS 端点，按 `INVALIDATION_MAP` invalidate React Query 缓存；指数退避自动重连（1s → 30s）
- **移除定时轮询**：`useTasks`（5s）、`useCron`（10s）、`DashboardPage`（30s）改为 WS 事件驱动 + `staleTime`，减少无效请求

## Test plan

- [ ] `backend/tests/unit/test_notification_bus.py` — 覆盖 subscribe/publish/unsubscribe/慢消费者/广播等 9 个场景
- [ ] `backend/tests/integration/test_notifications_ws.py` — WebSocket 连接、消息收发、心跳
- [ ] 手动验证：启动前后端，触发 SubAgent 任务或 Cron，观察前端 Tasks/Cron 页面无需刷新自动更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)